### PR TITLE
Fix Windows path handling in log directory creation

### DIFF
--- a/src/wordpress.ts
+++ b/src/wordpress.ts
@@ -63,8 +63,8 @@ export async function initWordPress() {
 }
 
 // Configure logging
-const META_URL = import.meta.url.replace(/^file:/, '');
-const LOG_DIR = path.join(META_URL.split('/').slice(0, -1).join('/'), '../logs');
+const META_URL = import.meta.url.replace(/^file:\/\/\//, '');
+const LOG_DIR = path.join(path.dirname(META_URL), '../logs');
 const LOG_FILE = path.join(LOG_DIR, 'wordpress-api.log');
 
 // Ensure log directory exists


### PR DESCRIPTION
## Fix Windows path handling in log directory creation

### Problem
The current code causes path duplication issues on Windows systems, resulting in `ENOENT: no such file or directory, mkdir 'C:\C:\...'` errors when trying to create the logs directory.

### Root Cause
- Improper `import.meta.url` handling for Windows file paths
- Manual path manipulation instead of using Node.js path utilities

### Solution
- Use `path.dirname()` for proper cross-platform directory path handling
- Fix file protocol prefix removal for Windows compatibility

### Testing
- Tested on Windows with Node.js v22.17.0
- Server now starts successfully without path errors
- MCP server integrates properly with Claude Desktop

### Files Changed
- `src/wordpress.ts`: Updated log directory path construction