### PR TITLE
fix: use stderr instead of stdout for signal handler messages

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -85,24 +85,25 @@ async function main() {
 }
 
 // Handle process signals and errors
+// IMPORTANT: MCP uses stdout for JSON-RPC — never use console.log here
 process.on('SIGTERM', () => {
-    console.log('Received SIGTERM signal, shutting down...');
+    process.stderr.write('[SHUTDOWN] Received SIGTERM, shutting down...\n');
     process.exit(0);
 });
 process.on('SIGINT', () => {
-    console.log('Received SIGINT signal, shutting down...');
+    process.stderr.write('[SHUTDOWN] Received SIGINT, shutting down...\n');
     process.exit(0);
 });
 process.on('uncaughtException', (error) => {
-    console.error('Uncaught exception:', error);
+    process.stderr.write(`[FATAL] Uncaught exception: ${error}\n`);
     process.exit(1);
 });
 process.on('unhandledRejection', (error) => {
-    console.error('Unhandled rejection:', error);
+    process.stderr.write(`[FATAL] Unhandled rejection: ${error}\n`);
     process.exit(1);
 });
 
 main().catch((error) => {
-    console.error('Startup error:', error);
+    process.stderr.write(`[FATAL] Startup error: ${error}\n`);
     process.exit(1);
 });

--- a/src/wordpress.ts
+++ b/src/wordpress.ts
@@ -160,7 +160,6 @@ Message: ${error.message}
 Status: ${error.response?.status || 'N/A'}
 Data: ${JSON.stringify(error.response?.data || {}, null, 2)}
 `;
-    console.error(errorLog);
     logToFile(errorLog);
     throw error;
   }
@@ -250,7 +249,6 @@ Message: ${error.message}
 Status: ${error.response?.status || 'N/A'}
 Data: ${JSON.stringify(error.response?.data || {}, null, 2)}
 `;
-    console.error(errorLog);
     logToFile(errorLog);
     throw error;
   }


### PR DESCRIPTION
## Summary

- Replace `console.log()` with `process.stderr.write()` in SIGTERM/SIGINT signal handlers
- Replace `console.error()` with `process.stderr.write()` in uncaught exception handlers
- Remove redundant `console.error()` calls in `wordpress.ts` error handlers (already handled by `logToFile()`)

## Problem

MCP servers communicate via stdout using JSON-RPC protocol. The signal handlers use `console.log('Received SIGTERM signal, shutting down...')` which writes to stdout, causing `SyntaxError: Unexpected token 'R', "Received S"... is not valid JSON` in MCP clients like Claude Desktop when the server receives a signal.

## Changes

| File | Change |
|------|--------|
| `src/server.ts` | `console.log` → `process.stderr.write` in SIGTERM/SIGINT handlers |
| `src/server.ts` | `console.error` → `process.stderr.write` in exception handlers |
| `src/wordpress.ts` | Remove redundant `console.error()` (logToFile already logs) |

## Test plan

- [ ] Start the MCP server via Claude Desktop
- [ ] Kill the server process (`kill -SIGTERM <pid>`) — should not produce JSON parse errors
- [ ] Verify error messages appear in stderr, not stdout