### PR TITLE
feat(wordpress): strip yoast_head fields from REST responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,26 @@ WORDPRESS_PASSWORD=wp_app_password
 
 # Optional: Custom SQL query endpoint (default: /mcp/v1/query)
 WORDPRESS_SQL_ENDPOINT=/mcp/v1/query
+
+# Optional: Comma-separated list of top-level fields to strip from
+# WordPress REST API responses before they are returned to the MCP
+# client. Defaults to "yoast_head,yoast_head_json" — read-only schema
+# markup that adds ~10KB to every response but is rarely useful to the
+# LLM. Set to an empty string to disable trimming.
+MCP_WP_STRIP_FIELDS=yoast_head,yoast_head_json
 ```
+
+## Response Trimming
+
+By default the server strips the top-level `yoast_head` and `yoast_head_json`
+fields from every WordPress REST API response before returning it to the MCP
+client. These fields contain Yoast SEO's pre-rendered schema markup, which the
+LLM almost never needs but pays tokens for on every request.
+
+- The trim applies to both single-object responses and arrays of objects.
+- Only **top-level** fields are stripped; nested objects are left untouched.
+- Override the list with the `MCP_WP_STRIP_FIELDS` environment variable
+  (comma-separated). Set it to an empty string to disable trimming entirely.
 
 ## Enabling SQL Query Tool (Optional)
 

--- a/src/wordpress.ts
+++ b/src/wordpress.ts
@@ -6,6 +6,46 @@ import { siteManager } from './config/site-manager.js';
 // Legacy global WordPress API client instance for backward compatibility
 let wpClient: AxiosInstance;
 
+const DEFAULT_STRIP_FIELDS = ['yoast_head', 'yoast_head_json'];
+
+/**
+ * Resolve the list of top-level fields to strip from WP REST responses.
+ * Reads MCP_WP_STRIP_FIELDS (comma-separated) and falls back to the default list.
+ * An empty string disables trimming.
+ */
+export function resolveStripFields(envValue?: string): string[] {
+  if (envValue === undefined) return DEFAULT_STRIP_FIELDS;
+  return envValue
+    .split(',')
+    .map(f => f.trim())
+    .filter(f => f.length > 0);
+}
+
+/**
+ * Pure function: return a shallow copy of `data` with `fields` removed at the
+ * top level. Arrays of objects are mapped; nested objects are left untouched.
+ * Non-object/non-array inputs (null, primitives) are returned as-is.
+ */
+export function trimResponseFields<T>(data: T, fields: string[]): T {
+  if (fields.length === 0) return data;
+  if (data === null || data === undefined) return data;
+
+  if (Array.isArray(data)) {
+    return data.map(item => trimResponseFields(item, fields)) as unknown as T;
+  }
+
+  if (typeof data === 'object') {
+    const fieldSet = new Set(fields);
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+      if (!fieldSet.has(key)) out[key] = value;
+    }
+    return out as T;
+  }
+
+  return data;
+}
+
 /**
  * Initialize the WordPress API client with authentication
  * Now uses SiteManager for multi-site support
@@ -106,8 +146,10 @@ Status: ${response.status}
 Data: ${JSON.stringify(response.data, null, 2)}
 `;
     logToFile(responseLog, 'debug');
-    
-    return options?.rawResponse ? response : response.data;
+
+    if (options?.rawResponse) return response;
+    const stripFields = resolveStripFields(process.env.MCP_WP_STRIP_FIELDS);
+    return trimResponseFields(response.data, stripFields);
   } catch (error: any) {
     const errorLog = `
 ERROR:


### PR DESCRIPTION
## Problem

Every WordPress REST API response that includes Yoast SEO data carries a `yoast_head` (escaped HTML) and a `yoast_head_json` field. Together these add roughly 10KB of pre-rendered schema markup to every single post / page response. When the MCP client is an LLM, that markup is paid for in tokens on every read and every write, but the LLM almost never needs it — it's SEO output meant for HTTP clients rendering pages, not for AI tools that are creating or editing content.

## Solution

Strip configured top-level fields from WP REST responses at the single chokepoint where every tool receives them — `makeWordPressRequest()` in `src/wordpress.ts`.

- Pure helper `trimResponseFields(data, fields)` handles both single objects and arrays of objects. Only **top-level** fields are stripped; nested objects are left intact.
- `resolveStripFields(envValue)` reads `MCP_WP_STRIP_FIELDS` (comma-separated) and falls back to the default `["yoast_head", "yoast_head_json"]`. Setting it to an empty string disables trimming.
- The existing `rawResponse: true` escape hatch on `makeWordPressRequest` bypasses trimming, so any caller that needs the raw axios response is unaffected.
- Trimming is **outbound only** — requests to WP are unchanged.

## What's tested

No automated tests in this PR — there's no test framework set up in the repo yet. The trim function was designed as a pure, exported helper so it can be covered cleanly in a follow-up PR that adds vitest. Behavior was sanity-checked against the six cases from the spec (single object, array of objects, nested objects untouched, empty input, missing fields, env-var override).

## Out of scope

- Adding a test framework — planned as a separate PR to keep this change small and reviewable.
- A verbose / raw-mode flag to selectively re-include trimmed fields per call. Easy to add later if there's demand.
- Two pre-existing TypeScript errors in `src/server.ts` (TS2589) and `src/tools/media.ts` (TS2345). Both exist on `main` already and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)