### PR TITLE
feat(content): warn when WordPress silently drops unregistered meta keys

### DIFF
--- a/scripts/manual-test-meta-warning.mjs
+++ b/scripts/manual-test-meta-warning.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Manual end-to-end test for the dropped-meta-key warning behavior.
+//
+// Usage:
+//   1. Configure .env with credentials for a real WP install (Yoast SEO
+//      active is the canonical case, but any install will do — the test
+//      just needs a key that WP will silently drop).
+//   2. From the repo root:  node scripts/manual-test-meta-warning.mjs
+//
+// What it does:
+//   - Initializes the WP client via the same code path the MCP server uses.
+//   - Creates a draft post.
+//   - Calls update_content with three deliberately-unregistered meta keys
+//     (`_yoast_wpseo_focuskw`, `_yoast_wpseo_metadesc`, `_yoast_wpseo_title`).
+//   - Asserts the warning content block appears in the toolResult.
+//   - Deletes the draft post (force) on cleanup.
+//
+// Exits 0 on success, non-zero on any assertion failure.
+
+import 'dotenv/config';
+import { initWordPress, makeWordPressRequest } from '../build/wordpress.js';
+import { unifiedContentHandlers } from '../build/tools/unified-content.js';
+
+const SCRATCH = {
+  title: 'meta warning manual test (delete me)',
+  status: 'draft',
+  content: 'created by scripts/manual-test-meta-warning.mjs',
+};
+
+const SENT_META = {
+  _yoast_wpseo_focuskw: 'manual-test',
+  _yoast_wpseo_metadesc: 'manual test description',
+  _yoast_wpseo_title: 'Manual Test Title',
+};
+
+let createdId = null;
+let exitCode = 0;
+
+function fail(msg) {
+  console.error('FAIL:', msg);
+  exitCode = 1;
+}
+
+function pass(msg) {
+  console.log('PASS:', msg);
+}
+
+try {
+  await initWordPress();
+
+  const created = await makeWordPressRequest('POST', 'posts', SCRATCH);
+  createdId = created.id;
+  console.log(`Created scratch post id=${createdId}`);
+
+  const result = await unifiedContentHandlers.update_content({
+    content_type: 'post',
+    id: createdId,
+    meta: SENT_META,
+  });
+
+  const contentBlocks = result?.toolResult?.content;
+  if (!Array.isArray(contentBlocks) || contentBlocks.length === 0) {
+    fail('toolResult.content was empty or not an array');
+  } else {
+    const warningBlock = contentBlocks.find(
+      (b) => b && typeof b.text === 'string' && b.text.startsWith('Warning:'),
+    );
+
+    if (!warningBlock) {
+      fail('expected a Warning: content block, none found');
+      console.error('Got content blocks:', JSON.stringify(contentBlocks, null, 2));
+    } else {
+      pass('warning content block present');
+      for (const key of Object.keys(SENT_META)) {
+        if (!warningBlock.text.includes(key)) {
+          fail(`warning text missing key: ${key}`);
+        } else {
+          pass(`warning mentions ${key}`);
+        }
+      }
+    }
+  }
+} catch (err) {
+  fail(`unhandled error: ${err.message}`);
+  console.error(err);
+} finally {
+  if (createdId) {
+    try {
+      await makeWordPressRequest('DELETE', `posts/${createdId}`, { force: true });
+      console.log(`Cleaned up scratch post id=${createdId}`);
+    } catch (cleanupErr) {
+      console.warn(`Cleanup failed for id=${createdId}: ${cleanupErr.message}`);
+    }
+  }
+}
+
+process.exit(exitCode);

--- a/src/tools/unified-content.ts
+++ b/src/tools/unified-content.ts
@@ -405,6 +405,44 @@ async function processContent(
   return htmlContent;
 }
 
+// Return the meta keys that were sent in the request but don't appear in
+// the WP response's `meta` object. WordPress silently drops unregistered
+// meta keys on writes to /wp/v2/{type}/{id}, so absence in the echoed
+// response is the signal that a key wasn't persisted. The `responseData`
+// is the parsed WP REST response; we look for `responseData.meta` as the
+// echoed object. If the response shape is unexpected (no meta object,
+// or meta returned as an array rather than the usual keyed object), we
+// treat every sent key as dropped — conservative, but matches the
+// underlying "we can't confirm it stuck" signal.
+export function detectDroppedMetaKeys(
+  sent: Record<string, unknown> | undefined,
+  responseData: unknown
+): string[] {
+  if (!sent) return [];
+  const sentKeys = Object.keys(sent);
+  if (sentKeys.length === 0) return [];
+  if (!responseData || typeof responseData !== 'object' || Array.isArray(responseData)) {
+    return sentKeys;
+  }
+  const returnedMeta = (responseData as Record<string, unknown>).meta;
+  if (!returnedMeta || typeof returnedMeta !== 'object' || Array.isArray(returnedMeta)) {
+    return sentKeys;
+  }
+  const returnedKeys = new Set(Object.keys(returnedMeta as Record<string, unknown>));
+  return sentKeys.filter(k => !returnedKeys.has(k));
+}
+
+export function buildDroppedMetaWarning(droppedKeys: string[]): string {
+  return (
+    `Warning: WordPress did not persist these meta keys: ${droppedKeys.join(', ')}. ` +
+    `This usually means they are not registered for REST exposure via ` +
+    `register_post_meta(..., show_in_rest => true). Common culprits are SEO ` +
+    `plugin keys (Yoast _yoast_wpseo_*, Rank Math rank_math_*, AIOSEO _aioseo_*) ` +
+    `which the plugins do not expose on the core /wp/v2/ endpoints by default. ` +
+    `See README "Meta field limitations" for context.`
+  );
+}
+
 // Schema definitions
 const listContentSchema = z.object({
   content_type: z.string().describe("The content type slug (e.g., 'post', 'page', 'product', 'documentation')"),
@@ -682,13 +720,19 @@ export const unifiedContentHandlers = {
       });
       
       const response = await makeWordPressRequest('POST', endpoint, contentData, { siteId: params.site_id });
-      
+
+      const responseContent: any[] = [{
+        type: 'text',
+        text: JSON.stringify(response, null, 2)
+      }];
+      const droppedMeta = detectDroppedMetaKeys(params.meta, response);
+      if (droppedMeta.length > 0) {
+        responseContent.unshift({ type: 'text', text: buildDroppedMetaWarning(droppedMeta) });
+      }
+
       return {
         toolResult: {
-          content: [{ 
-            type: 'text', 
-            text: JSON.stringify(response, null, 2) 
-          }],
+          content: responseContent,
           isError: false
         }
       };
@@ -742,22 +786,28 @@ export const unifiedContentHandlers = {
       }
       
       const response = await makeWordPressRequest('POST', `${endpoint}/${params.id}`, updateData, { siteId: params.site_id });
-      
+
+      const responseContent: any[] = [{
+        type: 'text',
+        text: JSON.stringify(response, null, 2)
+      }];
+      const droppedMeta = detectDroppedMetaKeys(params.meta, response);
+      if (droppedMeta.length > 0) {
+        responseContent.unshift({ type: 'text', text: buildDroppedMetaWarning(droppedMeta) });
+      }
+
       return {
         toolResult: {
-          content: [{ 
-            type: 'text', 
-            text: JSON.stringify(response, null, 2) 
-          }],
+          content: responseContent,
           isError: false
         }
       };
     } catch (error: any) {
       return {
         toolResult: {
-          content: [{ 
-            type: 'text', 
-            text: `Error updating content: ${error.message}` 
+          content: [{
+            type: 'text',
+            text: `Error updating content: ${error.message}`
           }],
           isError: true
         }
@@ -906,19 +956,25 @@ export const unifiedContentHandlers = {
 
           const updatedContent = await makeWordPressRequest('POST', `${endpoint}/${content.id}`, updateData, { siteId: params.site_id });
 
+          const responseContent: any[] = [{
+            type: 'text',
+            text: JSON.stringify({
+              found: true,
+              content_type: contentType,
+              content_id: content.id,
+              original_url: params.url,
+              updated: true,
+              content: updatedContent
+            }, null, 2)
+          }];
+          const droppedMeta = detectDroppedMetaKeys(params.update_fields.meta, updatedContent);
+          if (droppedMeta.length > 0) {
+            responseContent.unshift({ type: 'text', text: buildDroppedMetaWarning(droppedMeta) });
+          }
+
           return {
             toolResult: {
-              content: [{
-                type: 'text',
-                text: JSON.stringify({
-                  found: true,
-                  content_type: contentType,
-                  content_id: content.id,
-                  original_url: params.url,
-                  updated: true,
-                  content: updatedContent
-                }, null, 2)
-              }],
+              content: responseContent,
               isError: false
             }
           };
@@ -965,19 +1021,25 @@ export const unifiedContentHandlers = {
 
         const updatedContent = await makeWordPressRequest('POST', `${endpoint}/${content.id}`, updateData, { siteId: params.site_id });
 
+        const responseContent: any[] = [{
+          type: 'text',
+          text: JSON.stringify({
+            found: true,
+            content_type: contentType,
+            content_id: content.id,
+            original_url: params.url,
+            updated: true,
+            content: updatedContent
+          }, null, 2)
+        }];
+        const droppedMeta = detectDroppedMetaKeys(params.update_fields.meta, updatedContent);
+        if (droppedMeta.length > 0) {
+          responseContent.unshift({ type: 'text', text: buildDroppedMetaWarning(droppedMeta) });
+        }
+
         return {
           toolResult: {
-            content: [{
-              type: 'text',
-              text: JSON.stringify({
-                found: true,
-                content_type: contentType,
-                content_id: content.id,
-                original_url: params.url,
-                updated: true,
-                content: updatedContent
-              }, null, 2)
-            }],
+            content: responseContent,
             isError: false
           }
         };


### PR DESCRIPTION
## Summary

WordPress core silently drops any meta key sent via `/wp/v2/{type}/{id}` unless the key was registered via `register_post_meta(..., ['show_in_rest' => true])`. The big SEO plugins (Yoast SEO, Rank Math, AIOSEO) deliberately do not register their `_yoast_wpseo_*` / `rank_math_*` / `_aioseo_*` keys for core REST exposure — they ship their own routes (e.g. Yoast's `/yoast/v1/*` indexable endpoints).

As a result, calling `update_content` (or `create_content`, or `find_content_by_url` with `update_fields.meta`) with SEO meta keys returns 200 OK while the values silently never land. The MCP tool result echoed the API response back to the LLM with no indication anything had gone wrong, so callers reported success.

This PR adds a defensive diff: after each successful write, the handler compares the `meta` keys sent in the request to the `meta` keys echoed in the WP response. If any are missing, it prepends a `Warning:` content block to the `toolResult` listing every dropped key with a short explanation. It does **not** change which keys WP will accept — that requires a small WordPress companion plugin (being scoped separately at `mcp-wp-seo-bridge`).

## Root cause / diagnosis

Reproduced against a live Yoast-active install:

| Key sent | Registered with `show_in_rest`? | Result in response.meta |
|---|---|---|
| `_genesis_layout` | yes (by Genesis) | accepted, round-trips |
| `_test_made_up_key` | no | silently dropped |
| `_yoast_wpseo_focuskw` | no | silently dropped |

Single POST request, one key kept, two dropped, no error. This is core WP behavior and not something the MCP server can fix — but it can at least stop hiding the failure.

## Changes

- New module-level helpers in `src/tools/unified-content.ts`:
  - `detectDroppedMetaKeys(sent, responseData)` — returns the keys present in `sent` but missing from `responseData.meta`. Pure function, no I/O. Treats unexpected response shapes (no `meta`, or `meta` as an array) as "all dropped" — conservative.
  - `buildDroppedMetaWarning(keys)` — builds the warning text, including a pointer to the README "Meta field limitations" section (added in a follow-up doc PR).
- Wired the helpers into the four write paths that accept `meta`:
  - `create_content`
  - `update_content`
  - `find_content_by_url` (both the priority-types-matched and all-types-fallback update branches)
- `scripts/manual-test-meta-warning.mjs` — end-to-end check against a real WP install (this repo currently has no automated test harness; the script is the agreed manual verification step).

The warning is added as a separate `text` content block prepended to `toolResult.content`. The WP response JSON is untouched so anything downstream that parses the response keeps working.

## What was tested

- Manual: `node scripts/manual-test-meta-warning.mjs` against a Yoast-active install. Creates a draft post, calls `update_content` with three `_yoast_wpseo_*` keys, asserts the warning block appears and lists each sent key, deletes the post. Passes.
- Build: `npm run build`. Two pre-existing TS errors in `server.ts` and `media.ts` are unrelated to this change (present on `main` before this PR).

## Security considerations

- No new auth boundary. The handlers still forward `meta` to WordPress exactly as before — WP's existing `register_post_meta` / `auth_callback` enforcement is the only gate on what actually persists.
- The warning text contains the meta key names sent by the caller. These come from the MCP request, not from WP — so this can't leak server-side data the caller didn't already have.
- The change does not add an allowlist. There is no allowlist on the MCP side by design; the fix for the underlying drop is plugin-side registration (separate PR/repo).

## Keys that still won't work after this PR

All of them. This PR doesn't make any new keys writable — it just stops pretending the writes worked when they didn't. The follow-up companion plugin (`mcp-wp-seo-bridge`, separate repo) will register the actual SEO keys with `show_in_rest`.

## Test plan

- [ ] `npm run build` (warnings on pre-existing TS errors in server.ts and media.ts are unrelated)
- [ ] `node scripts/manual-test-meta-warning.mjs` against a Yoast-active install — expects PASS lines and exit 0
- [ ] In a Claude Desktop session: call `update_content` on a post with `meta: {_yoast_wpseo_metadesc: "test"}`. Tool output should include both a Warning block and the JSON response.
- [ ] Same call with a known-registered meta key (e.g. `_genesis_layout: "content-sidebar"` on a Genesis site) — no warning block expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)