### PR TITLE
docs(wordpress): document WPRM recipe card support via custom_fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,87 @@ All taxonomy operations use a single `taxonomy` parameter:
 }
 ```
 
+#### Recipe Cards (WP Recipe Maker)
+
+Sites running [WP Recipe Maker](https://wordpress.org/plugins/wp-recipe-maker/) (WPRM) store recipe cards in a separate `wprm_recipe` custom post type referenced by shortcode from the surrounding blog post. The unified content tools handle these recipes directly — no recipe-specific tool family is needed.
+
+**Reading recipes** — `get_content`, `list_content`, `find_content_by_url`, and `get_content_by_slug` all work with `content_type: "wprm_recipe"`. WPRM exposes the full structured recipe payload as a `recipe` field on the REST response, including ingredients, instructions, times, equipment, nutrition, notes, and rating.
+
+**Writing recipes** — pass the recipe payload via `custom_fields.recipe` on `create_content` or `update_content`. WPRM hooks into the WordPress REST insert action (`rest_insert_wprm_recipe`) and reads `recipe` from the request body root, so any field documented by WPRM's data model is accepted.
+
+> The `recipe` payload must be passed via `custom_fields` (which spreads at the request body root). The `meta` parameter nests its values under a `meta` key, which never reaches WPRM's REST hook.
+
+Example update:
+
+```json
+{
+  "content_type": "wprm_recipe",
+  "id": 4274,
+  "custom_fields": {
+    "recipe": {
+      "name": "Easy Smoked Asparagus",
+      "summary": "Smoky asparagus with hot honey.",
+      "servings": "4",
+      "servings_unit": "people",
+      "prep_time": "5",
+      "cook_time": "60",
+      "total_time": "65",
+      "ingredients": [
+        {
+          "name": "",
+          "ingredients": [
+            { "uid": 0, "amount": "1", "unit": "Bunch", "name": "Asparagus Spears", "notes": "" },
+            { "uid": 1, "amount": "1", "unit": "tbsp", "name": "Olive Oil", "notes": "" }
+          ]
+        }
+      ],
+      "instructions": [
+        {
+          "name": "",
+          "instructions": [
+            { "uid": 0, "name": "", "text": "Preheat smoker to 225°F.", "ingredients": [] },
+            { "uid": 1, "name": "", "text": "Drizzle with oil, season, smoke 1 hour.", "ingredients": [] }
+          ]
+        }
+      ],
+      "notes": "Thicker spears need more time."
+    }
+  }
+}
+```
+
+**Grouped ingredients and instructions** — recipes can split items into named groups like "For the sauce" / "For the chicken". Each entry in the outer `ingredients` (or `instructions`) array is one group with its own `name` and inner array:
+
+```json
+{
+  "ingredients": [
+    { "name": "For the sauce",   "ingredients": [ /* items */ ] },
+    { "name": "For the chicken", "ingredients": [ /* items */ ] }
+  ]
+}
+```
+
+Commonly used recipe fields:
+
+| Field           | Type            | Notes                                                |
+| --------------- | --------------- | ---------------------------------------------------- |
+| `name`          | string          | Recipe card title                                    |
+| `summary`       | string          | Short blurb (HTML allowed)                           |
+| `servings`      | string          | e.g. `"4"`                                           |
+| `servings_unit` | string          | e.g. `"people"`, `"servings"`                        |
+| `prep_time`     | string          | minutes, e.g. `"15"`                                 |
+| `cook_time`     | string          | minutes                                              |
+| `total_time`    | string          | minutes                                              |
+| `ingredients`   | array of groups | nested structure shown above                         |
+| `instructions`  | array of groups | nested structure shown above                         |
+| `notes`         | string          | HTML allowed                                         |
+| `equipment`     | array           | items shaped `{ id, name, notes, amount, uid }`      |
+| `image_url`     | string          | upload-by-URL when no `image_id` is supplied         |
+
+Course, cuisine, and keyword are stored as WPRM taxonomies (`wprm_course`, `wprm_cuisine`, `wprm_keyword`). Manage them with the unified taxonomy tools (`list_terms`, `create_term`, …) and link them to a recipe with `assign_terms_to_content`.
+
+WPRM auto-syncs `recipe.summary` back to the WordPress `post_content` field on save. If you want the post body and the recipe summary to differ, pass `content` explicitly alongside `custom_fields.recipe`.
+
 ## Configuration
 
 ### Single Site Configuration

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "start": "node ./build/server.js",
     "dev": "tsx watch src/server.ts",
     "clean": "rimraf build",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "npm run build"
   },
   "keywords": [
@@ -43,7 +45,8 @@
     "@types/node": "^22.10.0",
     "rimraf": "^5.0.5",
     "tsx": "^4.7.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^2.1.9"
   },
   "publishConfig": {
     "access": "public"

--- a/tests/tools/wprm-recipe.integration.test.ts
+++ b/tests/tools/wprm-recipe.integration.test.ts
@@ -1,0 +1,147 @@
+// Integration test: round-trip a WP Recipe Maker recipe through the unified
+// content handlers. Hits a real WordPress install. Skipped automatically when
+// credentials are not configured or the target site does not have WPRM.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as dotenv from 'dotenv';
+import { initWordPress, makeWordPressRequest } from '../../src/wordpress.js';
+import { unifiedContentHandlers } from '../../src/tools/unified-content.js';
+
+dotenv.config();
+
+const hasCreds =
+  !!process.env.WORDPRESS_API_URL &&
+  !!process.env.WORDPRESS_USERNAME &&
+  !!process.env.WORDPRESS_PASSWORD;
+
+function parseHandlerJson(result: any) {
+  if (result.toolResult.isError) {
+    throw new Error(`Handler returned error: ${result.toolResult.content[0]?.text}`);
+  }
+  return JSON.parse(result.toolResult.content[0].text);
+}
+
+describe.skipIf(!hasCreds)('wprm_recipe round-trip (integration)', () => {
+  let recipeId: number | null = null;
+  let wprmAvailable = false;
+
+  beforeAll(async () => {
+    await initWordPress();
+    try {
+      const types: any = await makeWordPressRequest('GET', 'types');
+      wprmAvailable = !!(types && types.wprm_recipe);
+    } catch {
+      wprmAvailable = false;
+    }
+  });
+
+  afterAll(async () => {
+    if (recipeId !== null) {
+      try {
+        await unifiedContentHandlers.delete_content({
+          content_type: 'wprm_recipe',
+          id: recipeId,
+          force: true,
+        } as any);
+      } catch {
+        // Best-effort cleanup; surface the test failure instead of this one.
+      }
+    }
+  });
+
+  it('creates a recipe with grouped ingredients via custom_fields.recipe', async (ctx) => {
+    if (!wprmAvailable) {
+      ctx.skip();
+      return;
+    }
+    const title = `mcp-wp integration test ${Date.now()}`;
+    const result = await unifiedContentHandlers.create_content({
+      content_type: 'wprm_recipe',
+      title,
+      content: 'Integration test recipe; safe to delete.',
+      status: 'draft',
+      custom_fields: {
+        recipe: {
+          name: title,
+          summary: 'Round-trip summary',
+          servings: '4',
+          servings_unit: 'people',
+          prep_time: '5',
+          cook_time: '20',
+          total_time: '25',
+          ingredients: [
+            {
+              name: 'For the sauce',
+              ingredients: [
+                { uid: 0, amount: '2', unit: 'tbsp', name: 'Soy sauce', notes: '' },
+                { uid: 1, amount: '1', unit: 'tsp', name: 'Sesame oil', notes: '' },
+              ],
+            },
+            {
+              name: 'For the chicken',
+              ingredients: [
+                { uid: 2, amount: '1', unit: 'lb', name: 'Chicken thigh', notes: 'boneless skinless' },
+              ],
+            },
+          ],
+          instructions: [
+            {
+              name: '',
+              instructions: [
+                { uid: 0, name: '', text: 'Whisk the sauce.', ingredients: [] },
+                { uid: 1, name: '', text: 'Marinate the chicken.', ingredients: [] },
+              ],
+            },
+          ],
+          notes: 'Round-trip test notes',
+        },
+      },
+    } as any);
+
+    const created = parseHandlerJson(result);
+    expect(typeof created.id).toBe('number');
+    expect(created.type).toBe('wprm_recipe');
+    expect(created.recipe?.servings).toBe('4');
+    expect(created.recipe?.prep_time).toBe('5');
+    expect(created.recipe?.cook_time).toBe('20');
+    expect(created.recipe?.total_time).toBe('25');
+    expect(created.recipe?.ingredients).toHaveLength(2);
+    expect(created.recipe?.ingredients?.[0]?.name).toBe('For the sauce');
+    expect(created.recipe?.ingredients?.[1]?.name).toBe('For the chicken');
+    expect(created.recipe?.instructions?.[0]?.instructions).toHaveLength(2);
+    expect(created.recipe?.notes).toContain('Round-trip test notes');
+
+    recipeId = created.id;
+  });
+
+  it('updates recipe fields via update_content and they persist on re-fetch', async (ctx) => {
+    if (!wprmAvailable || recipeId === null) {
+      ctx.skip();
+      return;
+    }
+    const updateResult = await unifiedContentHandlers.update_content({
+      content_type: 'wprm_recipe',
+      id: recipeId,
+      custom_fields: {
+        recipe: {
+          servings: '8',
+          total_time: '40',
+          notes: 'Updated round-trip notes',
+        },
+      },
+    } as any);
+
+    const updated = parseHandlerJson(updateResult);
+    expect(updated.recipe?.servings).toBe('8');
+    expect(updated.recipe?.total_time).toBe('40');
+    expect(updated.recipe?.notes).toContain('Updated round-trip notes');
+
+    const fetchResult = await unifiedContentHandlers.get_content({
+      content_type: 'wprm_recipe',
+      id: recipeId,
+    } as any);
+    const fetched = parseHandlerJson(fetchResult);
+    expect(fetched.recipe?.servings).toBe('8');
+    expect(fetched.recipe?.total_time).toBe('40');
+    expect(fetched.recipe?.notes).toContain('Updated round-trip notes');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    clearMocks: true,
+    env: {
+      DISABLE_LOGGING: 'true',
+    },
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary

WP Recipe Maker (WPRM) sites — including most WordPress food blogs — store the structured recipe (ingredients, instructions, times, nutrition) in a separate `wprm_recipe` custom post type referenced by shortcode from the surrounding blog post. The unified content tools could already read these recipes via the standard `/wp/v2/wprm_recipe/` endpoint, but it wasn't obvious that *writes* worked too.

**Path taken: document existing functionality.** No new tools.

After probing the live REST surface and reading the WPRM source, the path through the existing tools is clean: WPRM hooks `rest_insert_wprm_recipe` and reads a top-level `recipe` object out of the request body, so passing the WPRM payload via `custom_fields.recipe` on `create_content` / `update_content` round-trips the full recipe — including grouped ingredients ("For the sauce" / "For the chicken") and instructions. This was confirmed by a live round-trip on a real WPRM-enabled site.

The one tripwire worth calling out: the recipe payload must go via `custom_fields` (which spreads at the request body root), not `meta` (which nests under a `meta` key and never reaches WPRM's hook). The README now spells this out.

## What's in this PR

- **README** — new "Recipe Cards (WP Recipe Maker)" section under Key Advantages: how reads work, the worked `update_content` example with grouped ingredients, the meta-vs-custom_fields note, a field reference table, and a note that WPRM auto-syncs `recipe.summary` back to `post_content`.
- **Integration test** — `tests/tools/wprm-recipe.integration.test.ts` round-trips a recipe end-to-end against a real WPRM-enabled WordPress site: creates a draft with grouped ingredients/instructions/times via `custom_fields.recipe`, updates fields, re-fetches to confirm persistence, and cleans up via `delete_content` in `afterAll`.
- **Vitest setup** — minimal `vitest.config.ts` and `test` / `test:watch` scripts in `package.json`. The integration test skips automatically when WordPress credentials are absent or the target site doesn't have WPRM installed, so it's safe in CI without secrets.

Out of scope (per the original task brief): bulk recipe edits, recipe rating/review fields, recipe video fields.

## Test plan

- [x] `npm test` with no `.env` → suite skips cleanly (2 skipped, 0 failed)
- [x] `npm test` with `.env` pointing at a real WPRM site → 2 passed in ~5s, draft recipe cleaned up
- [x] Verified that `custom_fields.recipe` round-trips servings, times, summary, notes, **grouped** ingredients (two groups), and instructions
- [x] Verified that re-fetching after `update_content` returns the updated fields (not just the response echo)
- [x] `tsc --project tsconfig.json --noEmit` — no new errors introduced (two pre-existing errors on `main` remain, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)