### PR TITLE
fix(build): resolve TS2589 in server.ts and axios header type drift in media.ts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -54,8 +54,10 @@ for (const tool of allTools) {
     // const jsonSchema = zodToJsonSchema(z.object(tool.inputSchema.properties as z.ZodRawShape));
     // const parsedSchema = z.any().optional().parse(jsonSchema);
 
-    const zodSchema = z.object(tool.inputSchema.properties as z.ZodRawShape); 
-    server.tool(tool.name, zodSchema.shape, wrappedHandler)
+    const rawShape = tool.inputSchema.properties as z.ZodRawShape;
+    // Cast bypasses TS2589: server.tool's generic resolves ShapeOutput<Args>
+    // against the SDK's z3|z4 union schema type, exploding instantiation depth.
+    (server.tool as (name: string, schema: z.ZodRawShape, cb: typeof wrappedHandler) => unknown)(tool.name, rawShape, wrappedHandler);
 
 }
 

--- a/src/tools/media.ts
+++ b/src/tools/media.ts
@@ -255,7 +255,8 @@ async function loadUploadFromUrl(sourceUrl: string, explicitTitle?: string): Pro
   }
 
   const response = await axios.get<ArrayBuffer>(sourceUrl, { responseType: 'arraybuffer' });
-  const mimeType = normalizeMimeType(response.headers['content-type']);
+  const contentTypeHeader = response.headers['content-type'];
+  const mimeType = normalizeMimeType(typeof contentTypeHeader === 'string' ? contentTypeHeader : undefined);
   const originalFilename = deriveFilenameFromUrl(sourceUrl, mimeType);
   const filename = buildUploadFilename(originalFilename, explicitTitle);
 


### PR DESCRIPTION
## Summary

`npm run build` currently fails on `main` with two TypeScript errors. This PR addresses both:

- **`src/server.ts:58` (TS2589)** — `server.tool` is generic over `Args extends ZodRawShapeCompat`, and `ToolCallback<Args>` resolves `ShapeOutput<Args>` against the SDK's combined zod v3 / zod v4 schema union (`z3.ZodTypeAny | z4.$ZodType`). Inferring `Args` from the project's tool input shapes blows past TypeScript's instantiation depth. Passing the raw shape through a flat call-site cast keeps the runtime behavior identical while stopping inference from recursing through the dual-zod compat types.
- **`src/tools/media.ts:258` (TS2345)** — `response.headers['content-type']` is typed `AxiosHeaderValue | undefined` (which includes `string[] | number | boolean | null`), but `normalizeMimeType` only accepts `string | undefined`. Narrow to a `string` before passing it in; non-string values fall through to the existing `application/octet-stream` default.

After both changes, `npm run build` is clean.

## Test plan

- [x] `npm run build` succeeds with no errors
- [ ] Smoke-test `create_media` with `source_url` to confirm the narrowing still yields the expected MIME type on a normal HTTP response
- [ ] Confirm tool registration still works end-to-end by listing tools from a connected MCP client